### PR TITLE
Added toUpperCase to ignore the drive letter case comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function checkWin32(directoryPath) {
     driveData => {
       // Only get the drive which match the path
       const driveLetter = driveData[0]
-      return directoryPath.startsWith(driveLetter)
+      return directoryPath.toUpperCase().startsWith(driveLetter.toUpperCase())
     },
     {
       diskPath: 0,


### PR DESCRIPTION
When using path module on a different shell to execute the process on Windows the drive letter may return in lower case, this would cause the filter function to fail to identify the drive letter. Using toUppercase on both the path and the drive letter solves the issue.