### PR TITLE
fix: add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "types": "./dist/check-disk-space.d.ts",
   "exports": {
     "import": "./dist/check-disk-space.mjs",
-    "require": "./dist/check-disk-space.cjs"
+    "require": "./dist/check-disk-space.cjs",
+		"types": "./dist/check-disk-space.d.ts"
   },
   "scripts": {
     "build:lib": "rollup --config",


### PR DESCRIPTION
Using the new `resolvePackageJsonExports` option in TypeScript 5 requires the exports directive to include types, otherwise `tsc` complains:

`TS7016: Could not find a declaration file for module 'check-disk-space'. '<path>/node_modules/check-disk-space/dist/check-disk-space.mjs' implicitly has an 'any' type.   There are types at '<path>/node_modules/check-disk-space/dist/check-disk-space.d.ts', but this result could not be resolved when respecting package.json "exports". The 'check-disk-space' library may need to update its package.json or typings.
`