### PR TITLE
Explicit import of the process package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { execFile, execFileSync } from 'child_process'
 import { existsSync } from 'fs'
 import { release } from 'os'
 import { normalize, sep } from 'path'
+import process from 'process'
 
 import InvalidPathError from '@/src/errors/invalidPathError'
 import NoMatchError from '@/src/errors/noMatchError'


### PR DESCRIPTION
When using electron, the process package isn't imported by default. We need to explicitly import it so it can fill out the data (e.g process.platform).