### PR TITLE
fix(types): move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "module": "./dist/check-disk-space.mjs",
   "types": "./dist/check-disk-space.d.ts",
   "exports": {
+    "types": "./dist/check-disk-space.d.ts",
     "import": "./dist/check-disk-space.mjs",
-    "require": "./dist/check-disk-space.cjs",
-    "types": "./dist/check-disk-space.d.ts"
+    "require": "./dist/check-disk-space.cjs"
   },
   "scripts": {
     "build:lib": "rollup --config",


### PR DESCRIPTION
I moved `types` condition to the front (fixing a small issue introduced in https://github.com/highlightjs/highlight.js/pull/3736 ). `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ this PR focuses solely on fixing "🐛 Used fallback condition" problem but the "🎭 Masquerading as CJS" remains here. You can check the reported errors [here](https://arethetypeswrong.github.io/?p=check-disk-space%4011.8.0)